### PR TITLE
Adapts the plugin for 3.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > A plugin for [Oh My Fish][omf-link] to output the current working directory relative to environment variables.
 
 [![MIT License](https://img.shields.io/badge/license-MIT-007EC7.svg?style=flat-square)](/LICENSE)
-[![Fish Shell Version](https://img.shields.io/badge/fish-v2.2.0-007EC7.svg?style=flat-square)](https://fishshell.com)
+[![Fish Shell Version](https://img.shields.io/badge/fish-v3.2.2-007EC7.svg?style=flat-square)](https://fishshell.com)
 [![Oh My Fish Framework](https://img.shields.io/badge/Oh%20My%20Fish-Framework-007EC7.svg?style=flat-square)](https://www.github.com/oh-my-fish/oh-my-fish)
 
 <br/>

--- a/functions/epwd.fish
+++ b/functions/epwd.fish
@@ -17,7 +17,7 @@ function epwd -d "Output the current working directory relative to environment v
     set path_test (pwd | grep '^'$p)
     if test "$path_test" != ""
       set tmp_len (string length $p)
-      if test (math $tmp_len" > "$path_len) = "1"
+      if test $tmp_len -gt $path_len
         set path_matched $p
         set path_env_index $i
         set path_len $tmp_len
@@ -33,4 +33,3 @@ function epwd -d "Output the current working directory relative to environment v
     pwd
   end
 end
-


### PR DESCRIPTION
This is the error you get using this plugin with the newest fish (no idea when it started):

```
'14 > 0'
    ^
test: Missing argument at index 3
= 1
    ^
~/.config-msys2/fish/functions/epwd.fish (line 20):
      if test (math $tmp_len" > "$path_len) = "1"
         ^
in function 'epwd'
```

To check things like this, fish now wants you to use `test $NUM1 -gt $NUM2` for greater than.